### PR TITLE
Correct initialization of utmi_txvalid.

### DIFF
--- a/fpga/top_core.v
+++ b/fpga/top_core.v
@@ -52,7 +52,7 @@ wire                    dmpulldown_w;
 
 wire [7:0]              utmi_data_w = 8'b0;
 wire [7:0]              utmi_data_r;
-wire                    utmi_txvalid = 1'b1;
+wire                    utmi_txvalid = 1'b0;
 wire                    utmi_txready;
 wire                    utmi_rxvalid;
 wire                    utmi_rxactive;


### PR DESCRIPTION
Without this change the USB3300 starts driving D+ and D- immediately after initialization making sniffing impossible.